### PR TITLE
Improve and fix scripts

### DIFF
--- a/append_doc_feature.sh
+++ b/append_doc_feature.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 for var in "$@"
 do

--- a/append_info.sh
+++ b/append_info.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/usr/bin/env -S bash -euo pipefail
 
 for var in "$@"
 do

--- a/build_relm_docs.sh
+++ b/build_relm_docs.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env -S bash -euo pipefail
 
-mkdir docs
-mkdir docs/stable
-mkdir docs/next
+mkdir --parents docs/{stable,next} tmp
+pushd tmp
 
-mkdir tmp
-cd tmp
-
-git clone https://github.com/AaronErhardt/relm4 ./
-git checkout stable
+git clone --depth 1 --no-single-branch -- https://github.com/Relm4/Relm4 ./
+git switch --detach $(git tag --list --sort "v:refname" | grep -v - | tail -n 1)
 
 # Stable docs
 export STABLE=1
@@ -17,26 +13,27 @@ find -name "lib.rs" -exec ../append_doc_feature.sh {} +
 
 cargo update
 
-cd relm4-components
+pushd relm4-components
 cargo +nightly doc --all-features -Z rustdoc-scrape-examples
+popd
 
-cd ../relm4-macros
+pushd relm4-macros
 cargo +nightly doc --all-features
 # -Z rustdoc-scrape-examples
+popd
 
-cd ..
 cargo +nightly doc --all-features -Z rustdoc-scrape-examples
 
-cd ..
+popd
 
 mv tmp/target/doc/* docs/stable
 
 # Unstable docs
 export STABLE=0
-cd tmp
+pushd tmp
 
 git stash
-git checkout main
+git switch main
 
 cargo clean --doc
 cargo update
@@ -47,7 +44,7 @@ export RUSTDOCFLAGS="--cfg dox"
 
 cargo +nightly doc --all-features -Z rustdoc-scrape-examples
 
-cd ..
+popd
 
 mv tmp/target/doc/* docs/next
 

--- a/build_relm_docs.sh
+++ b/build_relm_docs.sh
@@ -1,7 +1,4 @@
-#!/bin/sh
-
-# Return on error
-set -e
+#!/usr/bin/env -S bash -euo pipefail
 
 mkdir docs
 mkdir docs/stable

--- a/fix_ssh.sh
+++ b/fix_ssh.sh
@@ -1,7 +1,4 @@
-#!/bin/bash
-
-# Return on error
-set -e
+#!/usr/bin/env -S bash -euo pipefail
 
 # Overwrite global SSH configuration
 echo "Host *


### PR DESCRIPTION
# Overview

Improve Bash scripts. Clean up inefficiencies. Fix cloned repository URL and checkouted branch.

# Changes
- Change shebang for the following scripts:
  - `append_doc_feature.sh`
  - `append_info.sh`
  - `build_relm_docs.sh`
  - `fix_ssh.sh`
- Change shell from `#!/bin/sh` to `#!/usr/bin/env -S bash -euo pipefail` for `build_relm_docs.sh` script. Bash is nicer to write.
- Use `DIRSTACK` (i.e. `pushd`/`popd`) instead of `cd` based directory traversal.
- Replace several `mkdir` calls with a single `mkdir --parents` call to create several directories at one run.
- Save a bit of bandwidth and time by not cloning full history of the repository. Instead clone only last commit of the tip of each branch, hence `--depth 1 --no-single-branch`.
- Replace repository URL of `https://github.com/AaronErhardt/relm4` with `https://github.com/Relm4/Relm4`. It looks like the `AaronErhardt/relm4` refer to some old repository and it doesn't exists anymore.
- Replace checkout of `stable` branch with checkout of latest stable tag, e.g. `v0.10.0`. `stable` branch does not exist at `Relm4/Relm4` repository anymore.